### PR TITLE
Add support for type safe event emitters

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,6 @@
 		"preview": "vite preview",
 		"storybook": "storybook dev -p 6006",
 		"build-storybook": "storybook build",
-		"postinstall": "cp -r dist/assets ../../../public",
-		"release": "./bin/release.sh",
 		"test": "jest",
 		"prepare": "husky install"
 	},

--- a/src/compiler/command-handlers/build-command/transformers/transform-call-expressions/transform-call-expressions.ts
+++ b/src/compiler/command-handlers/build-command/transformers/transform-call-expressions/transform-call-expressions.ts
@@ -4,7 +4,7 @@ import { pipe } from 'fp-ts/function';
 import { Keywords } from '../../../../compiler-types';
 
 function addRuntimeIntegration(node: ts.ClassDeclaration) {
-	const statements: ts.Statement[] = [];
+	const statementsThatMustBeOnTop: ts.Statement[] = [];
 	const existingConstructorDeclaration = node.members.find((member) =>
 		ts.isConstructorDeclaration(member)
 	) as ts.ConstructorDeclaration | undefined;
@@ -15,7 +15,7 @@ function addRuntimeIntegration(node: ts.ClassDeclaration) {
 	);
 
 	if (isDerived) {
-		statements.push(
+		statementsThatMustBeOnTop.push(
 			ts.factory.createExpressionStatement(
 				ts.factory.createCallExpression(ts.factory.createSuper(), undefined, [])
 			)
@@ -35,8 +35,7 @@ function addRuntimeIntegration(node: ts.ClassDeclaration) {
 				existingConstructorDeclaration?.parameters || [],
 				ts.factory.createBlock(
 					[
-						...(existingConstructorDeclaration?.body?.statements || []),
-						...statements,
+						...statementsThatMustBeOnTop,
 						ts.factory.createExpressionStatement(
 							ts.factory.createCallExpression(
 								ts.factory.createPropertyAccessExpression(
@@ -47,6 +46,7 @@ function addRuntimeIntegration(node: ts.ClassDeclaration) {
 								[ts.factory.createThis()]
 							)
 						),
+						...(existingConstructorDeclaration?.body?.statements || []),
 					],
 					true
 				)

--- a/src/compiler/command-handlers/compile-command/compile-command-handler.ts
+++ b/src/compiler/command-handlers/compile-command/compile-command-handler.ts
@@ -1,5 +1,5 @@
 import * as lodash from 'lodash';
-import { CompilerResponseCode } from '../../compiler-types';
+import { CompilerResponseCode, Keywords } from '../../compiler-types';
 import { CommandHandlerIterface } from '../command-handler.interface';
 import { KeywordParser } from '../utils/keyword-parser/keyword-parser';
 import compilerOptions from '../../compiler-options';
@@ -8,28 +8,14 @@ import { getGlobals } from '../../globals/compiled-global-interface';
 export class CompileCommandHandler extends CommandHandlerIterface {
 	private sourceDirectory = compilerOptions.rootDir!;
 
-	private getClassNames() {
+	async execute() {
 		const programTypeChecker = this.program.getTypeChecker();
 		const sourceFiles = this.program
 			.getSourceFiles()
 			.filter((sf) => sf.fileName.startsWith(this.sourceDirectory));
-		const keywordParser = new KeywordParser(sourceFiles, [], programTypeChecker);
-		const [constructorBased, injectables] = lodash.partition(
-			keywordParser.getClassesAndMethods(),
-			(_) => _.flags.isConstructorBased
-		);
-		return {
-			constructorBased: constructorBased.map((_) => _.className),
-			injectables: injectables.map((_) => _.className),
-		};
-	}
 
-	async execute() {
-		const { constructorBased, injectables } = this.getClassNames();
-		const compiledGlobals = getGlobals({
-			constructorBased,
-			injectableClassNames: injectables,
-		});
+		const keywordParser = new KeywordParser(sourceFiles, [], programTypeChecker);
+		const compiledGlobals = getGlobals(keywordParser.getClassesAndMethods());
 
 		this.outputMap.set('compiled-globals.d.ts', compiledGlobals);
 

--- a/src/compiler/command-handlers/utils/keyword-parser/keyword-parser.ts
+++ b/src/compiler/command-handlers/utils/keyword-parser/keyword-parser.ts
@@ -76,7 +76,7 @@ export class KeywordParser {
 		filePath: string
 	): Keywords[0] {
 		const className = classDeclaration.name?.escapedText! as string;
-
+		const typeParametersLength = classDeclaration.typeParameters?.length || 0;
 		const isClassMarked = true;
 		const isClassHidden = this.classesToHide
 			.map((_) => _.name?.getText())
@@ -120,6 +120,7 @@ export class KeywordParser {
 				},
 				methods: parsedMethods,
 				channelEmitters: [],
+				typeParametersLength,
 			};
 		}
 
@@ -138,6 +139,7 @@ export class KeywordParser {
 			},
 			methods: parsedMethods,
 			channelEmitters,
+			typeParametersLength,
 		};
 
 		const viewType = parsedClass.flags.view?.type;

--- a/src/compiler/command-handlers/utils/keyword-parser/keyword-parser.ts
+++ b/src/compiler/command-handlers/utils/keyword-parser/keyword-parser.ts
@@ -194,7 +194,7 @@ export class KeywordParser {
 
 		const channelEmitters = result.map((r) => ({
 			slug: (r.arguments[0] as ts.StringLiteral).text,
-			type: r.typeArguments?.at(0)?.getFullText(),
+			type: r.typeArguments?.at(0)?.getFullText() || 'undefined',
 		}));
 
 		return channelEmitters;

--- a/src/compiler/compiler-types.ts
+++ b/src/compiler/compiler-types.ts
@@ -46,6 +46,7 @@ export type Keyword = {
 		slug: string;
 		type: string | undefined;
 	}[];
+	typeParametersLength: number;
 };
 export type Keywords = Keyword[];
 export type ClassyKeywords = (Keyword & { class: { new (): any } })[];

--- a/src/compiler/compiler-types.ts
+++ b/src/compiler/compiler-types.ts
@@ -42,6 +42,10 @@ export type Keyword = {
 	flags: KeywordFlags;
 	filePath: string;
 	methods: ParsedMethod[];
+	channelEmitters: {
+		slug: string;
+		type: string | undefined;
+	}[];
 };
 export type Keywords = Keyword[];
 export type ClassyKeywords = (Keyword & { class: { new (): any } })[];

--- a/src/compiler/compiler-types.ts
+++ b/src/compiler/compiler-types.ts
@@ -44,7 +44,7 @@ export type Keyword = {
 	methods: ParsedMethod[];
 	channelEmitters: {
 		slug: string;
-		type: string | undefined;
+		type: string;
 	}[];
 	typeParametersLength: number;
 };

--- a/src/compiler/globals/compiled-global-interface.ts
+++ b/src/compiler/globals/compiled-global-interface.ts
@@ -45,6 +45,10 @@ export function getGlobals(params: { constructorBased: string[]; injectableClass
 			 run(): void;
 			 await(): RT;
 			}
+			declare class ChannelEmitter<T> {
+				emit(data: T): void;
+			}
+
 			type ScheduledFlow = { flow_type: 'scheduled_flow' }
 			type FlowFunction<T extends (...args: any) => any, Schedule> = (Schedule extends Record<any, any> ? ((...params: Parameters<T>) => ScheduledFlow) : ((...params: Parameters<T>) => std.FlowExecutor<ReturnType<T>, T>)) & { readonly __tag: unique symbol }
 			type FlowGenerator<T, Schedule> = {
@@ -98,6 +102,9 @@ export function getGlobals(params: { constructorBased: string[]; injectableClass
 			 * @link https://metz.sh
 			*/
 			function log(message?: any, ...optionalParams: any[]): void
+
+			function createChannelEmitter<T>(params: { slug: string; name: string }): std.ChannelEmitter<T>;
+			function registerChannelListener(slug: string, flowFunction: std.FlowFunction<any, 'immediate'>): () => void;
 		}
 	}
 	`;

--- a/src/compiler/globals/compiled-global-interface.ts
+++ b/src/compiler/globals/compiled-global-interface.ts
@@ -103,8 +103,8 @@ export function getGlobals(params: { constructorBased: string[]; injectableClass
 			*/
 			function log(message?: any, ...optionalParams: any[]): void
 
-			function createChannelEmitter<T>(params: { slug: string; name: string }): std.ChannelEmitter<T>;
-			function registerChannelListener(slug: string, flowFunction: std.FlowFunction<any, 'immediate'>): () => void;
+			function createChannelEmitter<T>(slug: string): std.ChannelEmitter<T>;
+			function registerChannelListener(slug: string, listener: (...args: any[]) => std.FlowExecutor<any, any>): () => void;
 		}
 	}
 	`;

--- a/src/compiler/utils/get-fqn-of-call.ts
+++ b/src/compiler/utils/get-fqn-of-call.ts
@@ -1,0 +1,22 @@
+import ts from 'typescript';
+import parseSymbol from './parse-symbol';
+
+export function getFQNsOfCall(node: ts.CallExpression, checker: ts.TypeChecker) {
+	const type = checker.getTypeAtLocation(node.expression);
+	const { symbol, isSymbolForbidden } = parseSymbol(type);
+	if (isSymbolForbidden) {
+		[];
+	}
+	if (!symbol) {
+		if (type.isUnion()) {
+			return type.types.map((subtype) => {
+				const symbol = subtype.getSymbol();
+				let fqn = checker.getFullyQualifiedName(symbol!);
+				return fqn;
+			});
+		}
+		return [];
+	}
+	const fqn = checker.getFullyQualifiedName(symbol);
+	return [fqn];
+}

--- a/src/compiler/utils/parse-symbol.ts
+++ b/src/compiler/utils/parse-symbol.ts
@@ -1,4 +1,4 @@
-const forbiddenSymbols = ['MetzFlowFunction'];
+const forbiddenSymbols: string[] = [];
 
 import type * as ts from 'typescript';
 export default function parseSymbol(type: ts.Type) {

--- a/src/compiler/utils/traverse-and-filter.ts
+++ b/src/compiler/utils/traverse-and-filter.ts
@@ -1,0 +1,21 @@
+import ts from 'typescript';
+
+export function traverseAndFilter<T extends ts.Node>(
+	node: ts.Node,
+	predicate: (node: ts.Node) => boolean
+): T[] {
+	const filteredNodes: T[] = [];
+
+	function traverse(currentNode: ts.Node): void {
+		if (predicate(currentNode)) {
+			filteredNodes.push(currentNode as T);
+		}
+
+		ts.forEachChild(currentNode, (child) => {
+			traverse(child);
+		});
+	}
+
+	traverse(node);
+	return filteredNodes;
+}

--- a/src/runtime/event-channels/channel-emitter.ts
+++ b/src/runtime/event-channels/channel-emitter.ts
@@ -1,0 +1,9 @@
+import { Channel } from './channel';
+
+export class ChannelEmitter {
+	constructor(readonly channel: Channel) {}
+
+	emit(data: any) {
+		this.channel.onEmit(data);
+	}
+}

--- a/src/runtime/event-channels/channel.ts
+++ b/src/runtime/event-channels/channel.ts
@@ -1,5 +1,4 @@
 import { FlowExecutor } from '../flow-executor';
-import { Address } from '../heap';
 
 export type ChannelListener = (...args: any[]) => FlowExecutor;
 
@@ -7,11 +6,9 @@ export class Channel {
 	private receivers = new Set<ChannelListener>();
 
 	private slug: string;
-	private name: string;
 
-	constructor(slug: string, name: string) {
+	constructor(slug: string) {
 		this.slug = slug;
-		this.name = name;
 	}
 
 	onEmit(data: any) {
@@ -32,7 +29,6 @@ export class Channel {
 	getIdentity() {
 		return {
 			slug: this.slug,
-			name: this.name,
 		};
 	}
 }

--- a/src/runtime/event-channels/channel.ts
+++ b/src/runtime/event-channels/channel.ts
@@ -1,0 +1,38 @@
+import { FlowExecutor } from '../flow-executor';
+import { Address } from '../heap';
+
+export type ChannelListener = (...args: any[]) => FlowExecutor;
+
+export class Channel {
+	private receivers = new Set<ChannelListener>();
+
+	private slug: string;
+	private name: string;
+
+	constructor(slug: string, name: string) {
+		this.slug = slug;
+		this.name = name;
+	}
+
+	onEmit(data: any) {
+		const flowFactories = Array.from(this.receivers);
+		for (const ff of flowFactories) {
+			ff(data).run();
+		}
+	}
+
+	addListener(listener: ChannelListener) {
+		this.receivers.add(listener);
+
+		return () => {
+			this.receivers.delete(listener);
+		};
+	}
+
+	getIdentity() {
+		return {
+			slug: this.slug,
+			name: this.name,
+		};
+	}
+}

--- a/src/runtime/event-channels/event-manager.ts
+++ b/src/runtime/event-channels/event-manager.ts
@@ -4,12 +4,12 @@ import { ChannelEmitter } from './channel-emitter';
 export class EventManager {
 	private channelMap = new Map<string, Channel>();
 
-	createChannelEmitter(params: { slug: string; name: string }) {
-		if (this.channelMap.has(params.slug)) {
+	createChannelEmitter(slug: string) {
+		if (this.channelMap.has(slug)) {
 			throw new Error('Channel already exists!');
 		}
-		const channel = new Channel(params.slug, params.name);
-		this.channelMap.set(params.slug, channel);
+		const channel = new Channel(slug);
+		this.channelMap.set(slug, channel);
 
 		return new ChannelEmitter(channel);
 	}

--- a/src/runtime/event-channels/event-manager.ts
+++ b/src/runtime/event-channels/event-manager.ts
@@ -1,0 +1,37 @@
+import { Channel, ChannelListener } from './channel';
+import { ChannelEmitter } from './channel-emitter';
+
+export class EventManager {
+	private channelMap = new Map<string, Channel>();
+
+	createChannelEmitter(params: { slug: string; name: string }) {
+		if (this.channelMap.has(params.slug)) {
+			throw new Error('Channel already exists!');
+		}
+		const channel = new Channel(params.slug, params.name);
+		this.channelMap.set(params.slug, channel);
+
+		return new ChannelEmitter(channel);
+	}
+
+	destroyChannel(slug: string) {
+		this.channelMap.delete(slug);
+	}
+
+	registerChannelListener(slug: string, listener: ChannelListener) {
+		const channel = this.channelMap.get(slug);
+		if (!channel) {
+			throw new Error('No such channel!');
+		}
+
+		return channel.addListener(listener);
+	}
+
+	getActiveChannels() {
+		return Array.from(this.channelMap, ([_, channel]) => channel);
+	}
+
+	reset() {
+		this.channelMap.clear();
+	}
+}

--- a/src/std/std.ts
+++ b/src/std/std.ts
@@ -1,4 +1,3 @@
-import * as lodash from 'lodash';
 import { Runtime } from '../runtime/runtime';
 import {
 	AwaitFlowInstruction,
@@ -8,6 +7,8 @@ import {
 	MethodRuntimeCommands,
 } from '../runtime/runtime-types';
 import { FlowExecutor } from '../runtime/flow-executor';
+import { ChannelEmitter } from '../runtime/event-channels/channel-emitter';
+import { ChannelListener } from '../runtime/event-channels/channel';
 
 function createAwaitFlowInstruction(params: {
 	flowExecutors: FlowExecutor[];
@@ -148,6 +149,14 @@ export function createStandardLibrary(runtime: Runtime, projectName: string) {
 
 		currentTick() {
 			return runtime.getCurrentTick();
+		},
+
+		createChannelEmitter(params: { slug: string; name: string }): ChannelEmitter {
+			return runtime.getEventManager().createChannelEmitter(params);
+		},
+
+		registerChannelListener(slug: string, listener: ChannelListener): () => void {
+			return runtime.getEventManager().registerChannelListener(slug, listener);
 		},
 	};
 }

--- a/src/std/std.ts
+++ b/src/std/std.ts
@@ -151,8 +151,8 @@ export function createStandardLibrary(runtime: Runtime, projectName: string) {
 			return runtime.getCurrentTick();
 		},
 
-		createChannelEmitter(params: { slug: string; name: string }): ChannelEmitter {
-			return runtime.getEventManager().createChannelEmitter(params);
+		createChannelEmitter(slug: string): ChannelEmitter {
+			return runtime.getEventManager().createChannelEmitter(slug);
 		},
 
 		registerChannelListener(slug: string, listener: ChannelListener): () => void {

--- a/src/stories/index.stories.tsx
+++ b/src/stories/index.stories.tsx
@@ -187,6 +187,7 @@ class NewService {
     @Injectable
     class BackendService {
 
+    	private emitter = std.createChannelEmitter({name: 'a', slug: 'a'});
       private healthy = false;
       private redis = new Redis<User>();
       private redis1 = new Redis<User>();

--- a/src/ui/components/ide/ide.tsx
+++ b/src/ui/components/ide/ide.tsx
@@ -82,13 +82,22 @@ export default function (props: { height?: string }) {
 		shallow
 	);
 
-	const { getActiveFilePath, editor, overlayed, monaco } = useIDE(
+	const {
+		getActiveFilePath,
+		editor,
+		overlayed,
+		monaco,
+		globalLibraryInitialized,
+		markGlobalLibraryInitialized,
+	} = useIDE(
 		(state) => ({
 			setActiveFilePath: state.setActiveFilePath,
 			getActiveFilePath: state.getActiveFilePath,
 			editor: state.editor,
 			overlayed: state.overlayed,
 			monaco: state.monaco,
+			globalLibraryInitialized: state.globalLibraryInitialized,
+			markGlobalLibraryInitialized: state.markGlobalLibraryInitialized,
 		}),
 		shallow
 	);
@@ -110,16 +119,19 @@ export default function (props: { height?: string }) {
 	}
 
 	useEffect(() => {
-		if (monaco._tag === 'None') {
+		if (monaco._tag === 'None' || globalLibraryInitialized) {
 			return;
 		}
-		addDefinitionsToMonaco([
+
+		addFilesToMonaco([
 			{
-				content: globalInterface,
-				filePath: 'globals.d.ts',
+				path: 'globals.d.ts',
+				value: globalInterface,
 			},
 		]);
-	}, [monaco]);
+
+		markGlobalLibraryInitialized();
+	}, [monaco, globalLibraryInitialized]);
 
 	useEffect(() => {
 		if (!isCompilerServiceReady) {

--- a/src/ui/state-managers/ide/globals/global-interface.ts
+++ b/src/ui/state-managers/ide/globals/global-interface.ts
@@ -1,34 +1,85 @@
 export default `
-interface Window {
-    /**
-     * Enables class to participate in Dependency Injection and makes it
-     * available via \`std.resolve\`
-     * 
-     * @Note But it also means that you can't construct it manually anymore.
-    */
-    declare function Injectable(constructor: Function): void;
+/**
+ * Globally available helper module
+*/
+declare module std {
+	class FlowExecutor<RT, M> {
+		run(): void;
+		await(): RT;
+	}
+	class ChannelEmitter<T> {
+		emit(data: T): void;
+	}
 
-    /**
-     * Marks annotated class as a DatabaseView. Renders the data source as a Relational Table.
-    */
-    declare function Table(columns: string[]): (constructor: Function)=> void;
+	type ScheduledFlow = { flow_type: 'scheduled_flow' }
+	type FlowFunction<T extends (...args: any) => any, Schedule> = (Schedule extends Record<any, any> ? ((...params: Parameters<T>) => ScheduledFlow) : ((...params: Parameters<T>) => std.FlowExecutor<ReturnType<T>, T>)) & { readonly __tag: unique symbol }
+	type FlowGenerator<T, Schedule> = {
+		[key in keyof T]: T[key] extends ((...args: any) => any) ? std.FlowFunction<T[key], Schedule> : never;
+	}
 
-    /**
-     * Marks annotated class as a DatabaseView. Renders the data source as a JSON collection.
-    */
-    declare function Collection(constructor: Function): void;
+	/**
+	 * Halts the flow for specified number of ticks
+	 * @param ticks Number of ticks to halt for
+	 * @link https://metz.sh
+	*/
+	function sleep(
+		ticks: number
+	): void
 
-    /**
-     * Marks annotated class as a DatabaseView. Renders the data source as a Key-Value Pair.
-    */
-    declare function KeyValue(constructor: Function): void;
+	/**
+	 * Gets the current tick of runtime. Equivalent of getting current time.
+	 * @link https://metz.sh
+	*/
+	function currentTick(): number
 
-    
-    /**
-     * Marks members of class which need to be displayed on playground.
-     * 
-     * @Note Has no effect on methods
-    */
-    declare function Show(target: Object, propertyKey: string | symbol): void;
+	function awaitAll<T extends FlowExecutor<any, any>[]>(
+		flows: [...T]
+	): { [K in keyof T]: T[K] extends FlowExecutor<infer RT, any> ? RT : never }
+
+	function awaitRace<T extends FlowExecutor<any, any>[]>(
+		flows: [...T]
+	): T[number] extends FlowExecutor<infer RT, any> ? RT : never
+
+	/**
+	 * Logs messages on playground
+	 * @link https://metz.sh
+	*/
+	function log(message?: any, ...optionalParams: any[]): void
+
+	function createChannelEmitter<T>(slug: string): std.ChannelEmitter<T>;
 }
+
+
+
+/**
+  * Enables class to participate in Dependency Injection and makes it
+  * available via \`std.resolve\`
+  *
+  * @Note But it also means that you can't construct it manually anymore.
+*/
+declare function Injectable(constructor: Function): void;
+
+/**
+  * Marks annotated class as a DatabaseView. Renders the data source as a Relational Table.
+*/
+declare function Table(columns: string[]): (constructor: Function)=> void;
+
+/**
+  * Marks annotated class as a DatabaseView. Renders the data source as a JSON collection.
+*/
+declare function Collection(constructor: Function): void;
+
+/**
+  * Marks annotated class as a DatabaseView. Renders the data source as a Key-Value Pair.
+*/
+declare function KeyValue(constructor: Function): void;
+
+
+/**
+  * Marks members of class which need to be displayed on playground.
+  *
+  * @Note Has no effect on methods
+*/
+declare function Show(target: Object, propertyKey: string | symbol): void;
+
 `;

--- a/src/ui/state-managers/ide/ide.state.ts
+++ b/src/ui/state-managers/ide/ide.state.ts
@@ -24,4 +24,7 @@ export type IDEState = {
 
 	enableOverlay(): void;
 	disableOverlay(): void;
+
+	globalLibraryInitialized: boolean;
+	markGlobalLibraryInitialized(): void;
 };

--- a/src/ui/state-managers/ide/ide.store.ts
+++ b/src/ui/state-managers/ide/ide.store.ts
@@ -4,7 +4,6 @@ import * as O from 'fp-ts/Option';
 import { ProjectState } from '../project/project.state';
 import { pipe } from 'fp-ts/function';
 import { IPosition, IRange, editor } from 'monaco-editor';
-import globalInterface from './globals/global-interface';
 
 function parseMonacoEditorOpenerCommand(
 	resource: Parameters<editor.ICodeEditorOpener['openCodeEditor']>[1],
@@ -49,11 +48,18 @@ export const createIDEStore = (
 	initialActiveFilePath?: string
 ) =>
 	createStore<IDEState>((set, get) => ({
+		globalLibraryInitialized: false,
 		activeFilePath: initialActiveFilePath,
 		monaco: O.none,
 		editor: O.none,
 
 		overlayed: false,
+
+		markGlobalLibraryInitialized() {
+			set({
+				globalLibraryInitialized: true,
+			});
+		},
 
 		setActiveFilePath(path?: string) {
 			set({


### PR DESCRIPTION
This closes #1  adds the ability to:
- Create channels
- Listen to channels

# Entities Added

### Channel
It has a slug, which marks its unique identifier. It maintains a `Set` of listeners and manages adding, deleting and most importantly sending data.

### ChannelEmitter
This is the interface that's exposed to users to help them create channels and emit events

## Update to standard Library
Added `std.createChannelEmitter` and `std.registerChannelListener`


