### PR TITLE
Added support for higher order functions

### DIFF
--- a/src/compiler/command-handlers/build-command/transformers/transform-call-expressions/method-body-parser.ts
+++ b/src/compiler/command-handlers/build-command/transformers/transform-call-expressions/method-body-parser.ts
@@ -531,7 +531,7 @@ export class MethodBodyParser {
 				})();
 
 				if (!isFunctionCallUnderOurPurview) {
-					return this.parseFunctionCallOutOfOurPurview(node);
+					return node;
 				}
 
 				return ts.factory.createParenthesizedExpression(
@@ -563,23 +563,6 @@ export class MethodBodyParser {
 		};
 
 		return visitor;
-	}
-
-	private parseFunctionCallOutOfOurPurview(node: ts.CallExpression) {
-		return ts.factory.updateCallExpression(
-			node,
-			node.expression,
-			node.typeArguments,
-			node.arguments.map((arg) => this.parseArgumentFunctionCallOutOfOurPurview(arg))
-		);
-	}
-
-	private parseArgumentFunctionCallOutOfOurPurview(expression: ts.Expression) {
-		const type = this.checker.getTypeAtLocation(expression);
-		const signatures = this.checker.getSignaturesOfType(type, ts.SignatureKind.Call);
-		const declarations = signatures.map((s) => s.declaration).filter((_) => !!_);
-
-		return expression;
 	}
 
 	private getForbiddenMethodVisitor(name: string) {

--- a/src/compiler/command-handlers/utils/keyword-parser/keyword-parser.ts
+++ b/src/compiler/command-handlers/utils/keyword-parser/keyword-parser.ts
@@ -6,6 +6,7 @@ import { ShowDecorator, parseClassDecorator, parseMethodDecorator } from './deco
 import { Keywords, Keyword, ParsedMethod } from '../../../compiler-types';
 import { traverseAndFilter } from '../../../utils/traverse-and-filter';
 import { getFQNsOfCall } from '../../../utils/get-fqn-of-call';
+import { extractClassAndMethod } from '../../../utils/extract-class-and-method';
 
 export class KeywordParser {
 	constructor(
@@ -178,7 +179,7 @@ export class KeywordParser {
 				return false;
 			}
 
-			const fqns = getFQNsOfCall(node, this.checker);
+			const fqns = getFQNsOfCall(node.expression, this.checker);
 			if (fqns.length > 1) {
 				return false;
 			}
@@ -283,12 +284,5 @@ export class KeywordParser {
 			})),
 			returnType: this.checker.typeToString(this.checker.getReturnTypeOfSignature(signature)),
 		};
-	}
-
-	private getHash(typeSignatures: (string | undefined)[]) {
-		const hash = typeSignatures
-			.map<string>((signature) => (signature ? removeWhitespace(signature) : ''))
-			.join();
-		return hash;
 	}
 }

--- a/src/compiler/utils/get-fqn-of-call.ts
+++ b/src/compiler/utils/get-fqn-of-call.ts
@@ -1,19 +1,24 @@
 import ts from 'typescript';
 import parseSymbol from './parse-symbol';
 
-export function getFQNsOfCall(node: ts.CallExpression, checker: ts.TypeChecker) {
-	const type = checker.getTypeAtLocation(node.expression);
+export function getFQNsOfCall(node: ts.Expression, checker: ts.TypeChecker): string[] {
+	const type = checker.getTypeAtLocation(node);
 	const { symbol, isSymbolForbidden } = parseSymbol(type);
 	if (isSymbolForbidden) {
 		[];
 	}
 	if (!symbol) {
 		if (type.isUnion()) {
-			return type.types.map((subtype) => {
-				const symbol = subtype.getSymbol();
-				let fqn = checker.getFullyQualifiedName(symbol!);
-				return fqn;
-			});
+			return type.types
+				.map((subtype) => {
+					const symbol = subtype.getSymbol();
+					if (!symbol) {
+						return;
+					}
+					let fqn = checker.getFullyQualifiedName(symbol);
+					return fqn;
+				})
+				.filter((_) => !!_) as string[];
 		}
 		return [];
 	}

--- a/src/compiler/utils/is-fqn-marked.ts
+++ b/src/compiler/utils/is-fqn-marked.ts
@@ -1,0 +1,21 @@
+import { Keywords } from '../compiler-types';
+import { extractClassAndMethod } from './extract-class-and-method';
+
+export function isFqnMarked(fqn: string, keywords: Keywords) {
+	const { className: destinationClassName, methodName: destinationMethodName } =
+		extractClassAndMethod(fqn);
+
+	const destinationClass = keywords.find((kw) => kw.className === destinationClassName);
+	if (!destinationClass) {
+		return false;
+	}
+
+	const destinationMethod = destinationClass.methods.find(
+		(m) => m.methodName === destinationMethodName
+	);
+	if (!destinationMethod) {
+		return false;
+	}
+
+	return destinationMethod.flags.isMarked;
+}

--- a/src/std/std.ts
+++ b/src/std/std.ts
@@ -158,5 +158,9 @@ export function createStandardLibrary(runtime: Runtime, projectName: string) {
 		registerChannelListener(slug: string, listener: ChannelListener): () => void {
 			return runtime.getEventManager().registerChannelListener(slug, listener);
 		},
+
+		lambda<T extends Function>(fn: T): T {
+			return fn;
+		},
 	};
 }

--- a/src/stories/index.stories.tsx
+++ b/src/stories/index.stories.tsx
@@ -118,62 +118,6 @@ class Users {
     `,
 	},
 	{
-		path: 'app/test.ts',
-		type: 'file' as const,
-		value: `/**
- * Auto generated code for a service.
- *
- * You can update this comment block and it will reflect
- * it as description on the playground!
-*/
-@Injectable
-class NewService {
-
-    @Show
-    private healthy = false;
-
-    /**
-     * Checks if all systems are good.
-    */
-    healthCheck() {
-        if(this.isDbReachable()) {
-            this.healthy = true;
-            return 200;
-        }
-
-        this.healthy = false;
-        return 500
-    }
-
-    /**
-     * Checks if DB connection is good.
-    */
-    isDbReachable() {
-        const isFailure = this.failRandomly(10);
-        std.log('DB failure', isFailure);
-        return !isFailure;
-    }
-
-    /**
-     * This won't show up in playground since it's private.
-     *
-     * It takes a failure probability in percentage and returns
-     * a boolean indicating if it indeed failed or not.
-    */
-    private failRandomly(failProbablityPercentage: number): boolean {
-        const parsedProbability = failProbablityPercentage/100;
-        const rand = Math.random();
-
-        if(rand <= parsedProbability) {
-            return true;
-        }
-
-        return false;
-    }
-
-}`,
-	},
-	{
 		path: 'app/server/backend.ts',
 		type: 'file' as const,
 		value: `
@@ -230,7 +174,7 @@ class NewService {
         //     return cachedUser;
         // }
 
-        const userFromDB = this.userTable.find(record => record.id === id);
+        const userFromDB = this.userTable.find(std.lambda(record => record.id === id));
         if(!userFromDB) {
             return
         }
@@ -283,98 +227,6 @@ class NewService {
 
     `,
 	},
-	// {
-	//   path: 'app/src/table.ts',
-	//   value: `
-	//   type NewEntity = {
-	//     id: string,
-	//     value: string,
-	//     createdAt: number,
-	// }
-
-	// @Injectable
-	// @Table(['id', 'value', 'createdAt'])
-	// class NewTable {
-
-	//     @Show
-	//     data: NewEntity[] = [];
-
-	//     insert(recordToInsert: Omit<NewEntity, 'createdAt'>) {
-	//         const record: NewEntity = {
-	//             ...recordToInsert,
-	//             createdAt: std.currentTick(),
-	//         };
-
-	//         this.data.push(record);
-	//         return record;
-	//     }
-
-	//     find(predicate: (record: NewEntity) => boolean) {
-	//         return this.data.find(predicate);
-	//     }
-
-	//     findAll(predicate: (record: NewEntity) => boolean) {
-	//         return this.data.filter(predicate);
-	//     }
-
-	//     update(
-	//         partialUpdate: Partial<NewEntity>,
-	//         predicate: (record: NewEntity) => boolean,
-	//     ) {
-	//       const indexOfRecord = this.data.findIndex(predicate);
-	//       if(indexOfRecord < 0) {
-	//           return;
-	//       }
-	//       const existingRecord = this.data[indexOfRecord];
-	//       const updatedRecord = {
-	//           ...existingRecord,
-	//           ...partialUpdate,
-	//       };
-
-	//       this.data[indexOfRecord] = updatedRecord;
-
-	//       return updatedRecord;
-	//     }
-
-	//     delete(predicate: (record: NewEntity) => boolean) {
-	//         const index = this.data.findIndex(predicate);
-	//         if(index < 0) {
-	//             return;
-	//         }
-	//         this.data.splice(index, 1);
-	//     }
-
-	// }
-	//   `,
-	// },
-	// {
-	//   path: 'app/kk/j.ts',
-	//   value: `
-	//   @Collection
-	//   @Injectable
-	//   class JAJAJAJAJAJAJAJA {
-	//     @Show
-	//     public data: {a: number, c: string}[] = [{a: 99, c:'1'}, {a: 69, c:'2'}, {a: 70, c:'3'}, {a: 71, c:'4'}]
-	//     j() {
-
-	//     }
-	//   }
-	//   `,
-	// },
-	// {
-	//   path: 'app/bb.ts',
-	//   value: `
-	//   class BB {
-	//     async nn() {
-	//       await this.wait();
-	//       return 69;
-	//     }
-
-	//     private async wait() {
-	//       return new Promise<number>(resolve=>setTimeout(()=>resolve(69), 5000))
-	//     }
-	//   }`,
-	// },
 ];
 
 const CodeDaemon = memo((props: {}) => {

--- a/src/ui/state-managers/ide/globals/global-interface.ts
+++ b/src/ui/state-managers/ide/globals/global-interface.ts
@@ -17,6 +17,8 @@ declare module std {
 		[key in keyof T]: T[key] extends ((...args: any) => any) ? std.FlowFunction<T[key], Schedule> : never;
 	}
 
+	function lambda<T extends Function>(fn: T): T
+
 	/**
 	 * Halts the flow for specified number of ticks
 	 * @param ticks Number of ticks to halt for


### PR DESCRIPTION
## Problem
Currently the compiler aggressively converts functions definitions into simulacrum native code. This leads to lambdas and other higher functions being passed around to get converted as well.

This is usually ok since simulacrum code is perfectly capable of calling these converted higher order functions.

The issue arises when it's not the simulacrum code which is calling this converted functions. For example, `filter` or any other internal JS function.

## Solution
In this PR, we add a simple check before building where arguments of such internal JS functions are checked and an exception is throws if they are explicitly talking converted functions. For example, calling a method from a class.

At the same time, `std.lambda` is provided as an escape hatch such that the compiler skips conversion.

## Showcase Code
```typescript
const userFromDB = this.userTable.find(
  //Rather than directly providing the lambda, we provide it through std
  std.lambda(record => record.id === id)
);
```