### PR TITLE
Add support for theme 36

### DIFF
--- a/src/ui/components/ide/monaco-editor.tsx
+++ b/src/ui/components/ide/monaco-editor.tsx
@@ -41,12 +41,11 @@ export default function (props: { onChange: OnChange }) {
 	const savedTheme = (localStorage.getItem('editorTheme') as 'dark' | 'light') || 'dark';
 	const [currentTheme, setCurrentTheme] = useState<'dark' | 'light'>(savedTheme);
 
-	// Function to toggle between light and dark themes
 	const toggleTheme = () => {
 		setCurrentTheme((prevTheme) => {
 			const newTheme = prevTheme === 'dark' ? 'light' : 'dark';
 			localStorage.setItem('editorTheme', newTheme); // Save the new theme to localStorage
-			return newTheme; // Return the new theme
+			return newTheme;
 		});
 	};
 
@@ -61,7 +60,6 @@ export default function (props: { onChange: OnChange }) {
 		monacoRef.editor.setTheme(currentTheme === 'dark' ? 'theme' : 'lightTheme');
 		localStorage.setItem('editorTheme', currentTheme);
 
-		monacoRef.editor.setTheme('theme');
 		monacoRef.languages.typescript.typescriptDefaults.setCompilerOptions({
 			...(compilerOptions as any),
 			noLib: true,

--- a/src/ui/components/ide/theme-light.json
+++ b/src/ui/components/ide/theme-light.json
@@ -1,0 +1,196 @@
+{
+	"base": "vs",
+	"inherit": true,
+	"rules": [
+		{
+			"background": "ff0000",
+			"token": ""
+		},
+		{
+			"foreground": "000000",
+			"background": "f0f0f0",
+			"token": "text"
+		},
+		{
+			"background": "ff0000",
+			"token": "source.ruby.rails.embedded.html"
+		},
+		{
+			"foreground": "000000",
+			"background": "e0e0e0",
+			"token": "text.html.ruby"
+		},
+		{
+			"foreground": "008000",
+			"token": "constant.numeric.ruby"
+		},
+		{
+			"foreground": "000000",
+			"background": "ff0000",
+			"token": "source"
+		},
+		{
+			"foreground": "999999",
+			"token": "comment"
+		},
+		{
+			"foreground": "0000cc",
+			"token": "constant"
+		},
+		{
+			"foreground": "ff4500",
+			"token": "keyword"
+		},
+		{
+			"foreground": "008080",
+			"token": "keyword.preprocessor"
+		},
+		{
+			"foreground": "000000",
+			"token": "keyword.preprocessor directive"
+		},
+		{
+			"foreground": "cc9900",
+			"token": "entity.name.function"
+		},
+		{
+			"foreground": "cc9900",
+			"token": "storage.type.function.js"
+		},
+		{
+			"fontStyle": "italic",
+			"token": "variable.parameter"
+		},
+		{
+			"foreground": "999999",
+			"background": "f0f0f0",
+			"token": "source comment.block"
+		},
+		{
+			"foreground": "000000",
+			"token": "variable.other"
+		},
+		{
+			"foreground": "008000",
+			"token": "support.function.activerecord.rails"
+		},
+		{
+			"foreground": "0000ff",
+			"token": "string"
+		},
+		{
+			"foreground": "aaaaaa",
+			"token": "string constant.character.escape"
+		},
+		{
+			"foreground": "000000",
+			"background": "cccc33",
+			"token": "string.interpolated"
+		},
+		{
+			"foreground": "008080",
+			"token": "string.regexp"
+		},
+		{
+			"foreground": "cccc33",
+			"token": "string.literal"
+		},
+		{
+			"foreground": "555555",
+			"token": "string.interpolated constant.character.escape"
+		},
+		{
+			"fontStyle": "underline",
+			"token": "entity.name.class"
+		},
+		{
+			"fontStyle": "underline",
+			"token": "support.class.js"
+		},
+		{
+			"fontStyle": "italic underline",
+			"token": "entity.other.inherited-class"
+		},
+		{
+			"foreground": "ff4500",
+			"token": "meta.tag.inline.any.html"
+		},
+		{
+			"foreground": "ff4500",
+			"token": "meta.tag.block.any.html"
+		},
+		{
+			"foreground": "99cc99",
+			"fontStyle": "italic",
+			"token": "entity.other.attribute-name"
+		},
+		{
+			"foreground": "cc9900",
+			"token": "keyword.other"
+		},
+		{
+			"foreground": "ff4500",
+			"token": "meta.selector.css"
+		},
+		{
+			"foreground": "ff4500",
+			"token": "entity.other.attribute-name.pseudo-class.css"
+		},
+		{
+			"foreground": "ff4500",
+			"token": "entity.name.tag.wildcard.css"
+		},
+		{
+			"foreground": "ff4500",
+			"token": "entity.other.attribute-name.id.css"
+		},
+		{
+			"foreground": "ff4500",
+			"token": "entity.other.attribute-name.class.css"
+		},
+		{
+			"foreground": "999966",
+			"token": "support.type.property-name.css"
+		},
+		{
+			"foreground": "000000",
+			"token": "keyword.other.unit.css"
+		},
+		{
+			"foreground": "000000",
+			"token": "constant.other.rgb-value.css"
+		},
+		{
+			"foreground": "000000",
+			"token": "constant.numeric.css"
+		},
+		{
+			"foreground": "000000",
+			"token": "support.function.event-handler.js"
+		},
+		{
+			"foreground": "000000",
+			"token": "keyword.operator.js"
+		},
+		{
+			"foreground": "cccc66",
+			"token": "keyword.control.js"
+		},
+		{
+			"foreground": "000000",
+			"token": "support.class.prototype.js"
+		},
+		{
+			"foreground": "ff4500",
+			"token": "object.property.function.prototype.js"
+		}
+	],
+	"colors": {
+		"editor.foreground": "#000000",
+		"editor.background": "#ffffff",
+		"editor.selectionBackground": "#d9d9d9",
+		"editor.lineHighlightBackground": "#f5f5f5",
+		"editorCursor.foreground": "#000000",
+		"editorWhitespace.foreground": "#404040"
+	}
+}

--- a/src/ui/components/ide/theme-manager/theme-manager.ts
+++ b/src/ui/components/ide/theme-manager/theme-manager.ts
@@ -1,0 +1,26 @@
+import { Theme } from './themes/theme.interface';
+import darkTheme from './themes/dark/dark-theme';
+import lightTheme from './themes/light/light-theme';
+
+class ThemeManager {
+	private themes: Map<string, Theme> = new Map();
+
+	constructor() {
+		this.themes.set(lightTheme.slug, lightTheme);
+		this.themes.set(darkTheme.slug, darkTheme);
+	}
+
+	getTheme(slug: string): Theme {
+		const theme = this.themes.get(slug);
+		if (!theme) {
+			throw new Error(`Theme with slug "${slug}" not found.`);
+		}
+		return theme;
+	}
+
+	getAllThemes(): Theme[] {
+		return Array.from(this.themes.values());
+	}
+}
+
+export default new ThemeManager();

--- a/src/ui/components/ide/theme-manager/theme-switcher.tsx
+++ b/src/ui/components/ide/theme-manager/theme-switcher.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Select } from '@mantine/core';
+import useThemeStore from './theme.store';
+
+const ThemeSwitcher: React.FC = () => {
+	const { currentTheme, switchTheme } = useThemeStore();
+
+	const themeOptions = [
+		{ value: 'light-theme', label: 'Light Theme' },
+		{ value: 'dark-theme', label: 'Dark Theme' },
+	];
+
+	const handleThemeChange = (themeSlug: string) => {
+		switchTheme(themeSlug);
+	};
+
+	return (
+		<Select
+			placeholder="Pick a theme"
+			value={currentTheme.slug}
+			onChange={handleThemeChange}
+			data={themeOptions}
+			sx={{
+				position: 'absolute',
+			}}
+		/>
+	);
+};
+
+export default ThemeSwitcher;

--- a/src/ui/components/ide/theme-manager/theme.store.ts
+++ b/src/ui/components/ide/theme-manager/theme.store.ts
@@ -1,0 +1,34 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { Theme } from './themes/theme.interface';
+import ThemeManager from './theme-manager';
+
+interface ThemeStore {
+	currentTheme: Theme;
+	switchTheme: (themeSlug: string) => void;
+}
+
+const useThemeStore = create<ThemeStore>()(
+	persist(
+		(set) => ({
+			currentTheme: ThemeManager.getTheme('dark-theme'), // Default theme
+			switchTheme: (themeSlug: string) => {
+				try {
+					const theme = ThemeManager.getTheme(themeSlug);
+					set({ currentTheme: theme });
+				} catch (error) {
+					if (error instanceof Error) {
+						console.error(error.message);
+					} else {
+						console.error('An unexpected error occurred');
+					}
+				}
+			},
+		}),
+		{
+			name: 'ide-theme',
+		}
+	)
+);
+
+export default useThemeStore;

--- a/src/ui/components/ide/theme-manager/themes/dark/dark-theme.ts
+++ b/src/ui/components/ide/theme-manager/themes/dark/dark-theme.ts
@@ -1,0 +1,11 @@
+import * as themeData from './theme.json';
+import { Theme } from '../theme.interface';
+
+const darkTheme: Theme = {
+	slug: 'dark-theme',
+	getJson(): Record<string, any> {
+		return themeData;
+	},
+};
+
+export default darkTheme;

--- a/src/ui/components/ide/theme-manager/themes/dark/theme.json
+++ b/src/ui/components/ide/theme-manager/themes/dark/theme.json
@@ -1,0 +1,196 @@
+{
+	"base": "vs-dark",
+	"inherit": true,
+	"rules": [
+		{
+			"background": "000000",
+			"token": ""
+		},
+		{
+			"foreground": "ffffff",
+			"background": "0f0f0f",
+			"token": "text"
+		},
+		{
+			"background": "000000",
+			"token": "source.ruby.rails.embedded.html"
+		},
+		{
+			"foreground": "ffffff",
+			"background": "101010",
+			"token": "text.html.ruby"
+		},
+		{
+			"foreground": "ccff33",
+			"token": "constant.numeric.ruby"
+		},
+		{
+			"foreground": "ffffff",
+			"background": "000000",
+			"token": "source"
+		},
+		{
+			"foreground": "9933cc",
+			"token": "comment"
+		},
+		{
+			"foreground": "339999",
+			"token": "constant"
+		},
+		{
+			"foreground": "ff6600",
+			"token": "keyword"
+		},
+		{
+			"foreground": "edf8f9",
+			"token": "keyword.preprocessor"
+		},
+		{
+			"foreground": "ffffff",
+			"token": "keyword.preprocessor directive"
+		},
+		{
+			"foreground": "ffcc00",
+			"token": "entity.name.function"
+		},
+		{
+			"foreground": "ffcc00",
+			"token": "storage.type.function.js"
+		},
+		{
+			"fontStyle": "italic",
+			"token": "variable.parameter"
+		},
+		{
+			"foreground": "772cb7",
+			"background": "070707",
+			"token": "source comment.block"
+		},
+		{
+			"foreground": "ffffff",
+			"token": "variable.other"
+		},
+		{
+			"foreground": "999966",
+			"token": "support.function.activerecord.rails"
+		},
+		{
+			"foreground": "66ff00",
+			"token": "string"
+		},
+		{
+			"foreground": "aaaaaa",
+			"token": "string constant.character.escape"
+		},
+		{
+			"foreground": "000000",
+			"background": "cccc33",
+			"token": "string.interpolated"
+		},
+		{
+			"foreground": "44b4cc",
+			"token": "string.regexp"
+		},
+		{
+			"foreground": "cccc33",
+			"token": "string.literal"
+		},
+		{
+			"foreground": "555555",
+			"token": "string.interpolated constant.character.escape"
+		},
+		{
+			"fontStyle": "underline",
+			"token": "entity.name.class"
+		},
+		{
+			"fontStyle": "underline",
+			"token": "support.class.js"
+		},
+		{
+			"fontStyle": "italic underline",
+			"token": "entity.other.inherited-class"
+		},
+		{
+			"foreground": "ff6600",
+			"token": "meta.tag.inline.any.html"
+		},
+		{
+			"foreground": "ff6600",
+			"token": "meta.tag.block.any.html"
+		},
+		{
+			"foreground": "99cc99",
+			"fontStyle": "italic",
+			"token": "entity.other.attribute-name"
+		},
+		{
+			"foreground": "dde93d",
+			"token": "keyword.other"
+		},
+		{
+			"foreground": "ff6600",
+			"token": "meta.selector.css"
+		},
+		{
+			"foreground": "ff6600",
+			"token": "entity.other.attribute-name.pseudo-class.css"
+		},
+		{
+			"foreground": "ff6600",
+			"token": "entity.name.tag.wildcard.css"
+		},
+		{
+			"foreground": "ff6600",
+			"token": "entity.other.attribute-name.id.css"
+		},
+		{
+			"foreground": "ff6600",
+			"token": "entity.other.attribute-name.class.css"
+		},
+		{
+			"foreground": "999966",
+			"token": "support.type.property-name.css"
+		},
+		{
+			"foreground": "ffffff",
+			"token": "keyword.other.unit.css"
+		},
+		{
+			"foreground": "ffffff",
+			"token": "constant.other.rgb-value.css"
+		},
+		{
+			"foreground": "ffffff",
+			"token": "constant.numeric.css"
+		},
+		{
+			"foreground": "ffffff",
+			"token": "support.function.event-handler.js"
+		},
+		{
+			"foreground": "ffffff",
+			"token": "keyword.operator.js"
+		},
+		{
+			"foreground": "cccc66",
+			"token": "keyword.control.js"
+		},
+		{
+			"foreground": "ffffff",
+			"token": "support.class.prototype.js"
+		},
+		{
+			"foreground": "ff6600",
+			"token": "object.property.function.prototype.js"
+		}
+	],
+	"colors": {
+		"editor.foreground": "#FFFFFF",
+		"editor.background": "#07090B",
+		"editor.selectionBackground": "#35493CE0",
+		"editor.lineHighlightBackground": "#22222f",
+		"editorCursor.foreground": "#FFFFFF",
+		"editorWhitespace.foreground": "#404040"
+	}
+}

--- a/src/ui/components/ide/theme-manager/themes/light/light-theme.ts
+++ b/src/ui/components/ide/theme-manager/themes/light/light-theme.ts
@@ -1,0 +1,11 @@
+import * as themeData from './theme.json';
+import { Theme } from '../theme.interface';
+
+const lightTheme: Theme = {
+	slug: 'light-theme',
+	getJson(): Record<string, any> {
+		return themeData;
+	},
+};
+
+export default lightTheme;

--- a/src/ui/components/ide/theme-manager/themes/light/theme.json
+++ b/src/ui/components/ide/theme-manager/themes/light/theme.json
@@ -1,0 +1,196 @@
+{
+	"base": "vs",
+	"inherit": true,
+	"rules": [
+		{
+			"background": "ff0000",
+			"token": ""
+		},
+		{
+			"foreground": "000000",
+			"background": "f0f0f0",
+			"token": "text"
+		},
+		{
+			"background": "ff0000",
+			"token": "source.ruby.rails.embedded.html"
+		},
+		{
+			"foreground": "000000",
+			"background": "e0e0e0",
+			"token": "text.html.ruby"
+		},
+		{
+			"foreground": "008000",
+			"token": "constant.numeric.ruby"
+		},
+		{
+			"foreground": "000000",
+			"background": "ff0000",
+			"token": "source"
+		},
+		{
+			"foreground": "999999",
+			"token": "comment"
+		},
+		{
+			"foreground": "0000cc",
+			"token": "constant"
+		},
+		{
+			"foreground": "ff4500",
+			"token": "keyword"
+		},
+		{
+			"foreground": "008080",
+			"token": "keyword.preprocessor"
+		},
+		{
+			"foreground": "000000",
+			"token": "keyword.preprocessor directive"
+		},
+		{
+			"foreground": "cc9900",
+			"token": "entity.name.function"
+		},
+		{
+			"foreground": "cc9900",
+			"token": "storage.type.function.js"
+		},
+		{
+			"fontStyle": "italic",
+			"token": "variable.parameter"
+		},
+		{
+			"foreground": "999999",
+			"background": "f0f0f0",
+			"token": "source comment.block"
+		},
+		{
+			"foreground": "000000",
+			"token": "variable.other"
+		},
+		{
+			"foreground": "008000",
+			"token": "support.function.activerecord.rails"
+		},
+		{
+			"foreground": "0000ff",
+			"token": "string"
+		},
+		{
+			"foreground": "aaaaaa",
+			"token": "string constant.character.escape"
+		},
+		{
+			"foreground": "000000",
+			"background": "cccc33",
+			"token": "string.interpolated"
+		},
+		{
+			"foreground": "008080",
+			"token": "string.regexp"
+		},
+		{
+			"foreground": "cccc33",
+			"token": "string.literal"
+		},
+		{
+			"foreground": "555555",
+			"token": "string.interpolated constant.character.escape"
+		},
+		{
+			"fontStyle": "underline",
+			"token": "entity.name.class"
+		},
+		{
+			"fontStyle": "underline",
+			"token": "support.class.js"
+		},
+		{
+			"fontStyle": "italic underline",
+			"token": "entity.other.inherited-class"
+		},
+		{
+			"foreground": "ff4500",
+			"token": "meta.tag.inline.any.html"
+		},
+		{
+			"foreground": "ff4500",
+			"token": "meta.tag.block.any.html"
+		},
+		{
+			"foreground": "99cc99",
+			"fontStyle": "italic",
+			"token": "entity.other.attribute-name"
+		},
+		{
+			"foreground": "cc9900",
+			"token": "keyword.other"
+		},
+		{
+			"foreground": "ff4500",
+			"token": "meta.selector.css"
+		},
+		{
+			"foreground": "ff4500",
+			"token": "entity.other.attribute-name.pseudo-class.css"
+		},
+		{
+			"foreground": "ff4500",
+			"token": "entity.name.tag.wildcard.css"
+		},
+		{
+			"foreground": "ff4500",
+			"token": "entity.other.attribute-name.id.css"
+		},
+		{
+			"foreground": "ff4500",
+			"token": "entity.other.attribute-name.class.css"
+		},
+		{
+			"foreground": "999966",
+			"token": "support.type.property-name.css"
+		},
+		{
+			"foreground": "000000",
+			"token": "keyword.other.unit.css"
+		},
+		{
+			"foreground": "000000",
+			"token": "constant.other.rgb-value.css"
+		},
+		{
+			"foreground": "000000",
+			"token": "constant.numeric.css"
+		},
+		{
+			"foreground": "000000",
+			"token": "support.function.event-handler.js"
+		},
+		{
+			"foreground": "000000",
+			"token": "keyword.operator.js"
+		},
+		{
+			"foreground": "cccc66",
+			"token": "keyword.control.js"
+		},
+		{
+			"foreground": "000000",
+			"token": "support.class.prototype.js"
+		},
+		{
+			"foreground": "ff4500",
+			"token": "object.property.function.prototype.js"
+		}
+	],
+	"colors": {
+		"editor.foreground": "#000000",
+		"editor.background": "#ffffff",
+		"editor.selectionBackground": "#d9d9d9",
+		"editor.lineHighlightBackground": "#f5f5f5",
+		"editorCursor.foreground": "#000000",
+		"editorWhitespace.foreground": "#404040"
+	}
+}

--- a/src/ui/components/ide/theme-manager/themes/theme.interface.ts
+++ b/src/ui/components/ide/theme-manager/themes/theme.interface.ts
@@ -1,0 +1,4 @@
+export interface Theme {
+	slug: string;
+	getJson(): Record<string, any>;
+}


### PR DESCRIPTION
### Fix color scheme for improved visibility (#36)

**Steps :**
1. Added a new file for theme as `theme-light.json`.
2. Define this new theme file in monaco editor as `lightTheme`.
3. Created state for theme change and storing the current theme in local storage.
4. Added a dropdown to toggle themes.

Light theme : 
<img width="966" alt="Screenshot 2024-10-05 at 10 20 39 PM" src="https://github.com/user-attachments/assets/d35a4ff2-b265-41d4-b70e-1e6b4eb5e7d9">

Dark theme : 
<img width="966" alt="Screenshot 2024-10-05 at 10 20 48 PM" src="https://github.com/user-attachments/assets/45df4c5c-6a5a-4b4e-abd2-e51ba421942a">
